### PR TITLE
Add optional CUDA matrix multiplication implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(USE_TBB "Enable TBB-backed matrix multiplication if available" ON)
 option(FETCH_TBB "Fetch oneTBB via FetchContent when TBB not found" OFF)
 option(ENABLE_WARNINGS "Enable reasonable compiler warnings" ON)
+option(USE_CUDA "Enable CUDA-backed matrix multiplication if available" OFF)
 
 # Compiler flags (non-invasive, controlled per-compiler)
 if(MSVC)
@@ -56,6 +57,18 @@ if(USE_TBB)
     endif()
 endif()
 
+# Optional CUDA-backed implementation
+if(USE_CUDA)
+    enable_language(CUDA)
+    find_package(CUDAToolkit REQUIRED)
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR}/src/matmul/cuda.cu)
+    set(CMAKE_CUDA_STANDARD 14)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    add_compile_definitions(HAVE_CUDA)
+    set(CUDA_AVAILABLE TRUE)
+    message(STATUS "CUDA enabled for matrix multiplication")
+endif()
+
 # -- Target ----------------------------------------------------------------
 add_executable(bench-matmul ${SOURCES})
 
@@ -78,12 +91,18 @@ if(TBB_AVAILABLE)
     endif()
 endif()
 
+# Link CUDA when available
+if(CUDA_AVAILABLE)
+    target_link_libraries(bench-matmul PRIVATE CUDA::cudart)
+endif()
+
 # Include directories (project-local headers)
 target_include_directories(bench-matmul PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
 # Helpful compile-time options
 target_compile_definitions(bench-matmul PRIVATE
     $<$<BOOL:${TBB_AVAILABLE}>:HAVE_TBB>
+    $<$<BOOL:${CUDA_AVAILABLE}>:HAVE_CUDA>
 )
 
 # Installation and packaging (small conveniences)
@@ -93,3 +112,4 @@ install(TARGETS bench-matmul RUNTIME DESTINATION bin)
 message(STATUS "Project: ${PROJECT_NAME}")
 message(STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
 message(STATUS "TBB support: ${TBB_AVAILABLE}")
+message(STATUS "CUDA support: ${CUDA_AVAILABLE}")

--- a/README.md
+++ b/README.md
@@ -256,15 +256,21 @@ the full implementation names:
 
 ## Implementations (short descriptions)
 
- `Naive-ijkLoop-Parallel` — naive triple-loop implementation parallelized across rows.
+- `Naive-ijkLoop` — baseline triple-loop implementation.
+- `Naive-ijkLoop-Parallel` — naive triple-loop implementation parallelized across rows.
+- `BlockTiled-CacheAware` — cache-aware blocked/tiled implementation.
+- `BlockTiled-CacheAware-Parallel` — threaded blocked/tiled implementation.
+- `RowColumn-Transposed` — transpose-based row × row dot-product implementation.
+- `BlockLocal-StackTranspose` — tile-local transpose into stack buffer.
 - `Scalar-LoopUnrolled` — scalar unrolled inner loops for ILP.
+- `SIMD-AVX2-Transposed` — AVX2 with pre-transposed input.
+- `SIMD-AVX2-Direct` — AVX2 without pre-transposition (direct loads).
 - `Parallel-SIMD-AVX2` — threaded + AVX2 vectorization.
 - `Parallel-Scalar-LoopUnrolled` — threaded scalar unrolled implementation.
-- `SIMD-AVX2-Direct` — AVX2 without pre-transposition (direct loads).
 - `Parallel-SIMD-Direct` — threaded variant of AVX2 direct loads.
-- `BlockLocal-StackTranspose` — tile-local transpose into stack buffer.
+- `Parallel-SIMD-Pthread` — pthread-backed SIMD implementation (when pthreads are available).
 - `Parallel-SIMD-TBB` — TBB-based task parallelism with AVX2 vectorization.
-- `CUDA-Naive` — CUDA kernel implementation (GPU).
+- `CUDA-Naive` — CUDA kernel implementation (GPU, when enabled).
 
 ## Output & verification
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ You can use short, convenient aliases when calling `run_benchmarks.py`. These ma
 
  - `naive` -> `Naive-ijkLoop`
  - `tiled` -> `BlockTiled-CacheAware`
+ - `naive-par` -> `Naive-ijkLoop-Parallel`
+ - `tiled-par` -> `BlockTiled-CacheAware-Parallel`
  - `avx2` -> `SIMD-AVX2-Transposed`
  - `avx2direct` -> `SIMD-AVX2-Direct`
  - `transposed` -> `RowColumn-Transposed`
@@ -107,6 +109,7 @@ You can use short, convenient aliases when calling `run_benchmarks.py`. These ma
  - `par-scalar` -> `Parallel-Scalar-LoopUnrolled`
  - `par-avx2-direct` -> `Parallel-SIMD-Direct`
  - `local` -> `BlockLocal-StackTranspose`
+ - `tbb` -> `Parallel-SIMD-TBB`
  - `cuda` -> `CUDA-Naive`
 
 If you prefer, you can also pass the full implementation names directly to `--run`.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - CMake
 - Linux (the program performs simple cache-detection via `/sys`)
 - Optional: CPU with AVX2 to exercise vectorized code paths
+- Optional: CUDA toolkit + NVIDIA GPU for the CUDA implementation
 
  ## Binary usage (quick reference)
 
@@ -100,6 +101,7 @@ You can use short, convenient aliases when calling `run_benchmarks.py`. These ma
  - `par-scalar` -> `Parallel-Scalar-LoopUnrolled`
  - `par-avx2-direct` -> `Parallel-SIMD-Direct`
  - `local` -> `BlockLocal-StackTranspose`
+ - `cuda` -> `CUDA-Naive`
 
 If you prefer, you can also pass the full implementation names directly to `--run`.
 
@@ -184,6 +186,13 @@ This section expands on each implementation included in the benchmark. Each entr
 	- Pros: High performance with less boilerplate for threading; dynamic scheduling.
 	- Cons: Requires TBB dependency; TBB runtime overhead for very small tasks.
 
+- **CUDA-Naive**
+	- Summary: Simple CUDA kernel that computes a dense matrix product on the GPU with one thread per output element.
+	- Complexity: O(N^3) total work; wall-clock benefits depend on GPU throughput and PCIe transfer overhead.
+	- Behavior: Transfers A and B to device, runs kernel, and copies C back to host.
+	- Pros: Enables GPU benchmarking within the same harness.
+	- Cons: Not yet optimized (no tiling/shared memory); transfer overhead can dominate for small N.
+
 If you'd like, I can move these items into a dedicated section with short pseudocode or diagrams for the trickier methods (block tiling, local stack transpose), or add notes about numeric reproducibility across methods and how to tune `BLOCK_SIZE` and thread counts for your machine.
 
 ## Optimization Techniques
@@ -243,6 +252,7 @@ the full implementation names:
 | `par-avx2-direct` | `Parallel-SIMD-Direct` |
 | `local` | `BlockLocal-StackTranspose` |
 | `tbb` | `Parallel-SIMD-TBB` |
+| `cuda` | `CUDA-Naive` |
 
 ## Implementations (short descriptions)
 
@@ -254,6 +264,7 @@ the full implementation names:
 - `Parallel-SIMD-Direct` — threaded variant of AVX2 direct loads.
 - `BlockLocal-StackTranspose` — tile-local transpose into stack buffer.
 - `Parallel-SIMD-TBB` — TBB-based task parallelism with AVX2 vectorization.
+- `CUDA-Naive` — CUDA kernel implementation (GPU).
 
 ## Output & verification
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Examples:
 # run two specific implementations for N=1024
 ./bench-matmul 1024 --run=BlockTiled-CacheAware,SIMD-AVX2-Transposed
 
+# run the CUDA implementation for N=1024 (requires USE_CUDA=ON build)
+./bench-matmul 1024 --run=CUDA-Naive
+
 # force baseline selection
 ./bench-matmul 512 --run=BlockTiled-CacheAware --baseline=Naive-ijkLoop
 ```
@@ -84,6 +87,9 @@ python3 run_benchmarks.py
 
 # run only two implementations for small sizes, two concurrent jobs
 python3 run_benchmarks.py --executable ./build/bench-matmul --run=naive,tiled --sizes=64,128 -j 2
+
+# run the CUDA implementation using an alias
+python3 run_benchmarks.py --executable ./build/bench-matmul --run=cuda --sizes=512
 
 # compare three implementations (aliases allowed)
 python3 run_benchmarks.py --executable ./build/bench-matmul --compare=tiled-par,tiled,naive --sizes=64 -j 1

--- a/include/matmul.h
+++ b/include/matmul.h
@@ -40,6 +40,11 @@ void multiplyMatricesOptimizedNoSIMDThreaded(float **matrixA, float **matrixB,
 void multiplyMatricesPthreadWrapper(float **matrixA, float **matrixB,
                                     float **result);
 
+#ifdef HAVE_CUDA
+// CUDA implementation
+void multiplyMatricesCUDA(float **matrixA, float **matrixB, float **result);
+#endif
+
 #ifdef HAVE_TBB
 // TBB wrapper
 void multiplyMatricesTBBWrapper(float **matrixA, float **matrixB,

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -22,7 +22,8 @@ ALIASES = {
     'local': 'BlockLocal-StackTranspose',
     'naive-par': 'Naive-ijkLoop-Parallel',
     'tiled-par': 'BlockTiled-CacheAware-Parallel',
-    'tbb': 'Parallel-SIMD-TBB'
+    'tbb': 'Parallel-SIMD-TBB',
+    'cuda': 'CUDA-Naive'
 }
 
 # Build reverse map: full method name -> alias (pick the first alias if duplicates)

--- a/src/main.cc
+++ b/src/main.cc
@@ -31,6 +31,10 @@ int main(int argc, char *argv[]) {
             {"SIMD-AVX2-Direct", multiplyMatricesAVX2NoTranspose},
             {"Parallel-SIMD-Direct", multiplyMatricesThreadedAVX2NoTranspose},
             {"BlockLocal-StackTranspose", multiplyMatricesLocalTranspose}
+#ifdef HAVE_CUDA
+            ,
+            {"CUDA-Naive", multiplyMatricesCUDA}
+#endif
 #ifdef HAVE_PTHREAD
             ,
             {"Parallel-SIMD-Pthread", multiplyMatricesPthreadWrapper}

--- a/src/matmul/cuda.cu
+++ b/src/matmul/cuda.cu
@@ -1,0 +1,95 @@
+#include "matmul.h"
+#include "utils.h"
+#include <cuda_runtime.h>
+#include <sstream>
+
+namespace {
+
+constexpr int kBlockDim = 16;
+
+__global__ void matmulKernel(const float *a, const float *b, float *c, int n) {
+  int row = blockIdx.y * blockDim.y + threadIdx.y;
+  int col = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (row < n && col < n) {
+    float sum = 0.0f;
+    int rowOffset = row * n;
+    for (int k = 0; k < n; ++k) {
+      sum += a[rowOffset + k] * b[k * n + col];
+    }
+    c[rowOffset + col] = sum;
+  }
+}
+
+bool checkCuda(cudaError_t status, const char *step) {
+  if (status == cudaSuccess) {
+    return true;
+  }
+  std::ostringstream os;
+  os << "CUDA error at " << step << ": " << cudaGetErrorString(status);
+  log(os.str());
+  return false;
+}
+
+} // namespace
+
+void multiplyMatricesCUDA(float **matrixA, float **matrixB, float **result) {
+  if (matrixA == nullptr || matrixB == nullptr || result == nullptr) {
+    log("CUDA: received null matrix pointer");
+    return;
+  }
+
+  int n = N;
+  size_t bytes = static_cast<size_t>(n) * static_cast<size_t>(n) *
+                 sizeof(float);
+
+  float *deviceA = nullptr;
+  float *deviceB = nullptr;
+  float *deviceC = nullptr;
+
+  if (!checkCuda(cudaMalloc(&deviceA, bytes), "cudaMalloc(A)") ||
+      !checkCuda(cudaMalloc(&deviceB, bytes), "cudaMalloc(B)") ||
+      !checkCuda(cudaMalloc(&deviceC, bytes), "cudaMalloc(C)")) {
+    cudaFree(deviceA);
+    cudaFree(deviceB);
+    cudaFree(deviceC);
+    return;
+  }
+
+  if (!checkCuda(cudaMemcpy(deviceA, matrixA[0], bytes,
+                            cudaMemcpyHostToDevice),
+                 "cudaMemcpy(A)") ||
+      !checkCuda(cudaMemcpy(deviceB, matrixB[0], bytes,
+                            cudaMemcpyHostToDevice),
+                 "cudaMemcpy(B)")) {
+    cudaFree(deviceA);
+    cudaFree(deviceB);
+    cudaFree(deviceC);
+    return;
+  }
+
+  dim3 block(kBlockDim, kBlockDim);
+  dim3 grid((n + block.x - 1) / block.x, (n + block.y - 1) / block.y);
+  matmulKernel<<<grid, block>>>(deviceA, deviceB, deviceC, n);
+
+  if (!checkCuda(cudaGetLastError(), "kernel launch") ||
+      !checkCuda(cudaDeviceSynchronize(), "cudaDeviceSynchronize")) {
+    cudaFree(deviceA);
+    cudaFree(deviceB);
+    cudaFree(deviceC);
+    return;
+  }
+
+  if (!checkCuda(cudaMemcpy(result[0], deviceC, bytes,
+                            cudaMemcpyDeviceToHost),
+                 "cudaMemcpy(C)")) {
+    cudaFree(deviceA);
+    cudaFree(deviceB);
+    cudaFree(deviceC);
+    return;
+  }
+
+  cudaFree(deviceA);
+  cudaFree(deviceB);
+  cudaFree(deviceC);
+}


### PR DESCRIPTION
### Motivation
- Provide an opt-in GPU-backed matrix multiplication path so the benchmark can exercise NVIDIA GPUs and compare CPU vs GPU implementations via a single harness.
- Ship a minimal, working CUDA baseline to enable further GPU optimizations and to document CUDA usage in the runner and README.

### Description
- Add a `USE_CUDA` CMake option that enables CUDA (`enable_language(CUDA)`), finds `CUDAToolkit`, appends `src/matmul/cuda.cu`, sets `HAVE_CUDA`, and links `CUDA::cudart` when available.
- Implement `src/matmul/cuda.cu` which provides `multiplyMatricesCUDA` and a naive per-output-element CUDA kernel with device allocation/copies, error checks via `checkCuda`, and host-device synchronization.
- Expose the CUDA function prototype in `include/matmul.h` under `#ifdef HAVE_CUDA` and register the method in `src/main.cc` as `"CUDA-Naive"` so it appears in the benchmark selection list.
- Update `README.md` and `run_benchmarks.py` to document CUDA requirements and add the `cuda` alias for the automated runner.

### Testing
- No automated tests were executed in this environment because the CUDA toolkit and an NVIDIA GPU were not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881c1012e48320932a1652ee2a0e4e)